### PR TITLE
New hook specs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - udata 2.0 / Python 3 support [#95](https://github.com/opendatateam/udata-recommendations/pull/95)
+- Support new hooks format [#96](https://github.com/opendatateam/udata-recommendations/pull/96)
 
 ## 1.0.1 (2018-08-03)
 

--- a/udata_recommendations/views.py
+++ b/udata_recommendations/views.py
@@ -8,8 +8,14 @@ from udata.frontend import template_hook
 blueprint = Blueprint('recommendations', __name__, template_folder='templates')
 
 
-@template_hook
-def dataset_recommendations(reco_ids):
+def has_recommendations(ctx):
+    dataset = ctx['dataset']
+    return 'recommendations' in dataset.extras and len(dataset.extras['recommendations'])
+
+
+@template_hook('dataset.display.after-description', when=has_recommendations)
+def dataset_recommendations(ctx):
+    reco_ids = ctx['dataset'].extras['recommendations']
     recommendations = Dataset.objects.filter(id__in=reco_ids)
     return theme.render('dataset-recommendations.html',
                         recommendations=recommendations)


### PR DESCRIPTION
This PR follows opendatateam/udata#2323 and migrate to the `dataset.display.after-description` hook