### PR TITLE
Fix default clean flag value

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -58,7 +58,7 @@ def test_dataset_reco_command(cli, rmock, mock_response, datasets):
     ds1, ds2, ds3 = datasets
     ds4 = DatasetFactory(extras={'recommendations': ['xxx']})
     rmock.get(MOCK_URL, json=mock_response)
-    result = cli('recommendations datasets')
+    result = cli('recommendations datasets --clean')
     assert 'Dataset recommendations filled for 1 dataset' in result.output
     # previous recommendations have been cleaned up
     ds4.reload()

--- a/udata_recommendations/commands.py
+++ b/udata_recommendations/commands.py
@@ -83,7 +83,7 @@ def process_dataset(idx, dataset):
 @recommendations.command()
 @click.option('-s', '--source', default=None,
               help='The source URL to get recommendations from')
-@click.option('-c', '--clean', is_flag=True, default=True,
+@click.option('-c', '--clean', is_flag=True, default=False,
               help='Cleanup existing recommendations')
 def datasets(source, clean):
     if clean:


### PR DESCRIPTION
The flag was set to true by default, recommendations were cleaned every time the command was executed. I think that the default behaviour should be to keep the existing recommendations and to delete recommendations when adding the `--clean` flag