### PR TITLE
Fix Matomo attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Update Matomo content tracking data-attributes [#263](https://github.com/opendatateam/udata-recommendations/pull/263)
 
 ## 3.1.4 (2023-03-07)
 

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,6 +1,6 @@
-pytest==4.6.3
-pytest-flask==0.15.0
-pytest-sugar==0.9.2
+pytest==7.2.1
+pytest-flask==1.2.0
+pytest-sugar==0.9.6
 requests-mock==1.7.0
 mock==3.0.5
 pytest-mock==2.0.0

--- a/udata_recommendations/templates/dataset-recommendations-externals.html
+++ b/udata_recommendations/templates/dataset-recommendations-externals.html
@@ -3,8 +3,8 @@
 {%- if messages and id %}
 <div 
     data-track-content
-    data-content-name="dataset external"
-    data-content-piece="reco"
+    data-content-name="external recommendations"
+    data-content-piece="{{ id }}"
     data-content-target="{{ id }}"
 >
     {{ banner_info_lg(

--- a/udata_recommendations/templates/dataset-recommendations-reuses.html
+++ b/udata_recommendations/templates/dataset-recommendations-reuses.html
@@ -12,8 +12,8 @@
                 class="fr-col-lg-3 fr-col-sm-6 fr-col-12"
                 data-track-content
                 data-content-name="reuse recommendations"
-                data-content-piece="reco {{ loop.idx }}"
-                data-content-target="reuses/{{ reuse.id }}"
+                data-content-piece="{{ reuse.title }}"
+                data-content-target="{{ url_for('reuses.show', reuse=reuse, _external=True) }}"
             >
                 {% include theme('reuse/card.html') with context %}
             </div>

--- a/udata_recommendations/templates/dataset-recommendations.html
+++ b/udata_recommendations/templates/dataset-recommendations.html
@@ -9,7 +9,7 @@
                 class="fr-mb-2w"
                 data-track-content
                 data-content-name="dataset recommendations"
-                data-content-piece="dataset.full_title"
+                data-content-piece="{{ dataset.full_title }}"
                 data-content-target="{{ url_for('datasets.show', dataset=dataset) }}"
             >
                 {% include theme('dataset/card-sm.html') with context %}

--- a/udata_recommendations/templates/dataset-recommendations.html
+++ b/udata_recommendations/templates/dataset-recommendations.html
@@ -9,8 +9,8 @@
                 class="fr-mb-2w"
                 data-track-content
                 data-content-name="dataset recommendations"
-                data-content-piece="reco {{ loop.idx }}"
-                data-content-target="datasets/{{ dataset.id }}"
+                data-content-piece="dataset.full_title"
+                data-content-target="{{ url_for('datasets.show', dataset=dataset) }}"
             >
                 {% include theme('dataset/card-sm.html') with context %}
             </div>


### PR DESCRIPTION
This PR changes the way we handle recommendations content in Matomo. 

## Before

Each recommendation type has a content name following the pattern `{type} recommendations` except external that uses `dataset externals`.
All recommendations have the same content piece `reco` because `loop.idx` is not set.

## After

Each recommendation type has a content name following the pattern `{type} recommendations` including external ones.
All recommendations have a content piece corresponding to the individual piece of content shown :

- a dataset or reuse recommendation has its title as piece
- an external recommendation has its url as piece

This allows Matomo to provide metrics for a type of recommendation but also for each piece. 