### PR TITLE
Unpin jsonschema deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Migrate to Python 3.11 following `udata` dependencies upgrade [#265](https://github.com/opendatateam/udata-recommendations/pull/265)
+- Unpin jsonschema deps [#266](https://github.com/opendatateam/udata-recommendations/pull/266)
 
 ## 3.1.5 (2023-11-21)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
 udata>=3.2.0
 udata-front>=3.1.3
-jsonschema==3.2.0
+jsonschema>=3.2.0


### PR DESCRIPTION
It gets in conflict with latest versions used in udata & udata-front (upgraded in https://github.com/opendatateam/udata/pull/3089).

When installing udata-recommendations, it would override any recent version of udata & udata-front by installing the ones previous to jsonschema upgrade.