### PR TITLE
Update deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: udata/circleci:2-alpine
+      - image: udata/circleci:py3.11-bookworm
       - image: mongo:6.0.4
       - image: redis:alpine
       - image: udata/elasticsearch:2.4.5
@@ -66,7 +66,7 @@ jobs:
 
   publish:
     docker:
-      - image: udata/circleci:2-alpine
+      - image: udata/circleci:py3.11-bookworm
     steps:
       - attach_workspace:
           at: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Update jsonschema dependency as well as develop and test deps [#267](https://github.com/opendatateam/udata-recommendations/pull/267)
 
 ## 3.1.6 (2024-07-30)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -1,5 +1,5 @@
 -e .[test]
-flake8==3.7.8
+flake8==7.1.2
 invoke==2.2.0
-pytest-cov==2.7.1
-twine==3.3.0
+pytest-cov==6.0.0
+twine==6.1.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
 udata>=3.2.0
 udata-front>=3.1.3
-jsonschema>=4.23.0
+jsonschema==4.23.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
 udata>=3.2.0
 udata-front>=3.1.3
-jsonschema>=3.2.0
+jsonschema>=4.23.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,5 @@
 mock==5.2.0
-pytest==8.3.5
+pytest==7.4.4
 pytest-flask==1.3.0
 pytest-mock==3.14.0
 pytest-sugar==1.0.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,6 +1,6 @@
-pytest==7.4.3
+mock==5.2.0
+pytest==8.3.5
 pytest-flask==1.3.0
-pytest-sugar==0.9.7
-requests-mock==1.11.0
-mock==5.0.1
-pytest-mock==3.11.1
+pytest-mock==3.14.0
+pytest-sugar==1.0.0
+requests-mock==1.12.1

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,6 @@ from flask import render_template_string, g
 
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.reuse.factories import ReuseFactory
-from udata.frontend.markdown import mdstrip
 
 
 def render_hook(dataset):
@@ -60,7 +59,7 @@ class TestViews:
         assert ds1.full_title in content
         assert ds2.full_title in content
         assert ds3.full_title not in content
-        assert mdstrip(r1.title, 55) in content_reuses
+        assert f'data-content-piece="{r1.title}"' in content_reuses
 
     @pytest.mark.options(RECOMMENDATIONS_NB_RECOMMENDATIONS=2)
     def test_view_dataset_with_recommendations_dedupe(self, datasets, reuses):
@@ -83,7 +82,7 @@ class TestViews:
         content_reuses = render_hook_reuses(dataset=dataset)
 
         assert content.count(f'href="{ds1.display_url}"') == 1
-        assert content_reuses.count(f'href="{r1.external_url}"') == 1
+        assert content_reuses.count(f'data-content-target="{r1.external_url}"') == 1
         assert ds1.full_title in content
         assert ds2.full_title not in content
         assert ds3.full_title in content


### PR DESCRIPTION
- jsonschema
- develop and test deps

# Issues
- with pytest >= 8.0.0 ([changelog](https://docs.pytest.org/en/stable/changelog.html#pytest-8-0-0rc1-2023-12-30)), tests fail due to `template_hook` not working.
It may be related to collection changes, but I couldn't find why precisely